### PR TITLE
Fix server string comparison bug

### DIFF
--- a/Server/src/Server/EchoServer.java
+++ b/Server/src/Server/EchoServer.java
@@ -1319,7 +1319,7 @@ public class EchoServer extends AbstractServer {
                             }
                         }
                     }
-                    if (book[6] == "")
+                    if (book[6].isEmpty())
                         book[6] = "No upcoming return date";
                 }
                 books.add(book);
@@ -1395,7 +1395,7 @@ public class EchoServer extends AbstractServer {
                             }
                         }
                     }
-                    if (book[6] == "")
+                    if (book[6].isEmpty())
                         book[6] = "No upcoming return date";
                 }
                 books.add(book);


### PR DESCRIPTION
## Summary
- fix incorrect string comparison in `EchoServer.getBookDetailsByGenre`
- update another branch with same issue

## Testing
- `javac --module-path /usr/share/openjfx/lib --add-modules javafx.controls,javafx.fxml -classpath "JARS/*" -d build @all_sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_684873167d58832b918476d64e922246